### PR TITLE
Clean URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+permalink: pretty


### PR DESCRIPTION
`pretty` is the `jekyll` `permalink` setting to remove `.html` extension from url